### PR TITLE
fix pom warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,10 +169,6 @@
           <version>2.2.1</version>
         </plugin>
         <plugin>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9.1</version>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
           <version>2.7</version>
@@ -223,7 +219,6 @@
                 <dataFile>${project.build.directory}/coverage.exec</dataFile>
               </configuration>
             </execution>
-
           </executions>
         </plugin>
       </plugins>


### PR DESCRIPTION
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.aliyun:tea:jar:0.0.1
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-javadoc-plugin @ line 187, column 17
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]