### PR TITLE
TeaResponse.getResponseBody() should close okhttp's Response quietly

### DIFF
--- a/src/main/java/com/aliyun/tea/TeaResponse.java
+++ b/src/main/java/com/aliyun/tea/TeaResponse.java
@@ -4,7 +4,7 @@ import com.aliyun.tea.utils.StringUtils;
 import okhttp3.Headers;
 import okhttp3.Response;
 
-import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +27,8 @@ public class TeaResponse {
         this.response = response;
         statusCode = response.code();
         statusMessage = response.message();
-        body = response.body().byteStream();
+        if (response.body() != null)
+            body = response.body().byteStream();
         Headers headers = response.headers();
         Map<String, List<String>> resultHeaders = headers.toMultimap();
         for (Map.Entry<String, List<String>> entry : resultHeaders.entrySet()) {
@@ -43,20 +44,12 @@ public class TeaResponse {
         if (null == body) {
             return String.format("{\"message\":\"%s\"}", statusMessage);
         }
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        byte[] buff = new byte[4096];
+
         try {
-            while (true) {
-                final int read = body.read(buff);
-                if (read == -1) {
-                    break;
-                }
-                os.write(buff, 0, read);
-            }
-        } catch (Exception e) {
+            return response.body().string();
+        } catch (IOException e) {
             throw new TeaException(e.getMessage(), e);
         }
-        return new String(os.toByteArray());
     }
 
 


### PR DESCRIPTION
TeaResponse.getResponseBody() should close okhttp's Response quietly, so use Response.body().string()

Such as alipay-easysdk (java) use TeaResponse.getResponseBody() to get body String, then parsed as json. 
But it will be warned by OKHttp: "forget to close a response body"

`2021-08-27 11:22:00.686 [OkHttp ConnectionPool] WARN  okhttp3.OkHttpClient - A connection to https://openapi.alipaydev.com/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);`

So use Response.body().string() to return body string, and it will be quietly closed Response. Another benefit: it will handle charset correctly (first from content-type then UTF-8), the original using new String(bytes) but it will use system default charset and maybe not UTF-8. 
