### PR TITLE
解析泛型类型

### DIFF
--- a/src/main/java/com/aliyun/tea/TeaModel.java
+++ b/src/main/java/com/aliyun/tea/TeaModel.java
@@ -182,7 +182,7 @@ public class TeaModel {
     private static <T extends TeaModel> T setTeaModelField(T model, Field field, Object value, boolean userBuild) {
         try {
             Class<?> clazz = field.getType();
-            Object resultValue = parseNumber(value, clazz);
+            Object resultValue = List.class.isAssignableFrom(clazz) ? parseArray(value, field.getGenericType()) : parseNumber(value, clazz);
             T result = model;
             if (TeaModel.class.isAssignableFrom(clazz)) {
                 Object data = clazz.getDeclaredConstructor().newInstance();
@@ -226,6 +226,20 @@ public class TeaModel {
             result = setTeaModelField(result, field, value, true);
         }
         return result;
+    }
+
+    private static Object parseArray(Object value, Type type) {
+        List<Object> res = new ArrayList<>();
+        if (value instanceof List) {
+            ParameterizedType pt = (ParameterizedType) type;
+            List temp = (List) value;
+            for (Object o : temp) {
+                Double v = Double.parseDouble(o.toString());
+                //将值转换为集合泛型类型
+                res.add(parseNumber(v, (Class) pt.getActualTypeArguments()[0]));
+            }
+        }
+        return res;
     }
 
     private static Object parseNumber(Object value, Class clazz) {


### PR DESCRIPTION
**集合内泛型类型未被正确解析**

字段`checkers`泛型类型为`Float`

```java
    public static class RecognizeVATInvoiceResponseBodyDataBox extends TeaModel {
        @NameInMap("Checkers")
        public List<Float> checkers;
        @NameInMap("Clerks")
        public List<Float> clerks;
        @NameInMap("InvoiceAmounts")
        public List<Float> invoiceAmounts;
        ....
}
```

经过请求后，泛型信息由`Float`变为了`Long`。

![image-20211224224417253](https://typora.xpp011.cn/typora/img/image-20211224224417253.png)







经过检查，问题出现在将请求后得到的`Map`解析为对应的`Model`时，丢失了泛型信息。(对此我将依赖`tea`升级至`1.1.15`也没有得到改善)

解析具体实现方法为

> com.aliyun.tea.TeaModel.setTeaModelField()

![image-20211224224233819](https://typora.xpp011.cn/typora/img/image-20211224224233819.png)





对此我新增了`parseArray()`方法，解决泛型信息丢失的问题

```java
    private static Object parseArray(Object value, Type type) {
        List<Object> res = new ArrayList<>();
        if (value instanceof List) {
            ParameterizedType pt = (ParameterizedType) type;
            List temp = (List) value;
            for (Object o : temp) {
                Double flag = Double.parseDouble(o.toString());
                //将值转换为集合泛型类型
                res.add(parseNumber(flag, (Class) pt.getActualTypeArguments()[0]));
            }
        }
        return res;
    }
```

![image-20211225000146383](https://typora.xpp011.cn/typora/img/image-20211225000146383.png)

